### PR TITLE
Change entrypoint from /manager to /jenkins-operator 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ out
 .kube
 .idea
 smoke/features/steps/__pycache__
+.DS_Store

--- a/manifests/jenkins-operator/0.0.0/manifests/jenkins-operator.0.0.0.clusterserviceversion.yaml
+++ b/manifests/jenkins-operator/0.0.0/manifests/jenkins-operator.0.0.0.clusterserviceversion.yaml
@@ -186,7 +186,7 @@ spec:
             spec:
               containers:
               - command:
-                - /manager
+                - /jenkins-operator
                 env:
                 - name: WATCH_NAMESPACE
                   valueFrom:


### PR DESCRIPTION
Change entrypoint from /manager to /jenkins-operator in 0.0.0 CVS for testing

This is required because of:
https://github.com/redhat-developer/jenkins-operator/blob/main/openshift-ci/Dockerfile.build_image#L65
